### PR TITLE
Retire project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # systemd compatibility libraries
 
+NOTE: this project is no longer under active development
+
 This is a standalone build of the compatibility libraries for systemd, which
 map library calls for systemd < 209 onto the new `libsystemd.so` provided by
 later versions. These libraries


### PR DESCRIPTION
This project is no longer needed from CentOS Linux 8 and CentOS Stream 8 onwards, so it's time to retire it.